### PR TITLE
Update to Go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster as build
+FROM golang:1.23-buster as build
 WORKDIR /go/src/app
 ADD ./mural /go/src/app
 RUN go build -o /go/bin/app ./cmd/mural/main.go 

--- a/mural/go.mod
+++ b/mural/go.mod
@@ -1,3 +1,3 @@
 module github.com/georgemblack/mural
 
-go 1.15
+go 1.23


### PR DESCRIPTION
## Summary
- update `go.mod` to use Go 1.23
- bump Dockerfile base image to `golang:1.23-buster`

## Testing
- `go mod tidy`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68461786f9248331b899869f8f3eada6