### PR TITLE
Fix file truncation and struct literal

### DIFF
--- a/mural/cmd/mural/main.go
+++ b/mural/cmd/mural/main.go
@@ -26,10 +26,10 @@ func main() {
 	flag.Parse()
 
 	config := mural.Config{
-		*inputDir,
-		*outputDir,
-		*sortDirection,
-		*sortStrength,
+		InputDir:      *inputDir,
+		OutputDir:     *outputDir,
+		SortDirection: *sortDirection,
+		SortStrength:  *sortStrength,
 	}
 
 	initLog(*logToFile)

--- a/mural/sort.go
+++ b/mural/sort.go
@@ -45,7 +45,7 @@ func sortImage(inputFilePath, outputDirPath string, strength int) error {
 
 	// create or open file in output dir
 	outputFilePath := outputDirPath + "/" + inputFileName
-	destFile, err := os.OpenFile(outputFilePath, os.O_WRONLY|os.O_CREATE, 0600)
+	destFile, err := os.OpenFile(outputFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- ensure image output files overwrite existing files
- use keyed fields for Config struct in CLI

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846174c00b0833189e5eb4fb72f9264